### PR TITLE
Don't depend on @angular/platform-browser-dynamic

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "@angular/common": "2.0.0",
     "@angular/compiler": "2.0.0",
     "@angular/platform-browser": "2.0.0",
-    "@angular/platform-browser-dynamic": "2.0.0",
     "@angular/router": "3.0.0",
     "rxjs": "5.0.0-beta.12",
     "zone.js": "^0.6.23"


### PR DESCRIPTION
It isn't really a mandatory dependency of the module and it makes trouble for the AoT compiler.

Thanks so much for building this by the way. It's great!