### PR TITLE
fix: loosen peer dependencies to allow usage with angular 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,13 +47,10 @@
   },
   "homepage": "https://github.com/Nolanus/ng2-page-scroll#readme",
   "peerDependencies": {
-    "@angular/core": "^2.4.0",
-    "@angular/common": "^2.4.0",
-    "@angular/compiler": "^2.4.0",
-    "@angular/platform-browser": "^2.4.0",
-    "@angular/router": "^3.2.0",
-    "rxjs": "^5.0.1",
-    "zone.js": "^0.7.2"
+    "@angular/core": ">=2.4.0 <5.0.0",
+    "@angular/common": ">=2.4.0 <5.0.0",
+    "@angular/platform-browser": ">=2.4.0 <5.0.0",
+    "@angular/router": ">=3.2.0 <5.0.0"
   },
   "devDependencies": {
     "@angular/common": "^2.4.0",


### PR DESCRIPTION
First of all thanks for the this great module! I've loosened the peer dependencies to allow angular 4 and removed zone.js and rxjs as they're already peer dependencies of `@angular/core`