### PR TITLE
Provide module with singleton pattern

### DIFF
--- a/ng2-page-scroll.ts
+++ b/ng2-page-scroll.ts
@@ -3,5 +3,4 @@ export * from './src/ng2-page-scroll.service';
 export * from './src/ng2-page-scroll-config';
 export * from './src/ng2-page-scroll-instance';
 export * from './src/ng2-page-scroll-util.service';
-
-export {Ng2PageScrollModule} from './src/ng2-page-scroll.module';
+export * from './src/ng2-page-scroll.module';

--- a/src/ng2-page-scroll.module.ts
+++ b/src/ng2-page-scroll.module.ts
@@ -5,13 +5,14 @@
 import {CommonModule} from '@angular/common';
 import {NgModule, ModuleWithProviders} from '@angular/core';
 
-import {PageScrollService} from './ng2-page-scroll.service';
+import {NG2PAGESCROLL_SERVICE_PROVIDER, PageScrollService} from './ng2-page-scroll.service';
 import {PageScroll} from './ng2-page-scroll.directive';
 
 @NgModule({
     imports: [CommonModule],
     declarations: [PageScroll],
-    exports: [PageScroll]
+    exports: [PageScroll],
+    providers: [NG2PAGESCROLL_SERVICE_PROVIDER]
 })
 export class Ng2PageScrollModule {
     static forRoot(): ModuleWithProviders {

--- a/src/ng2-page-scroll.service.ts
+++ b/src/ng2-page-scroll.service.ts
@@ -1,4 +1,4 @@
-import {Injectable, isDevMode} from '@angular/core';
+import {Injectable, Optional, SkipSelf, isDevMode} from '@angular/core';
 
 import {PageScrollConfig} from './ng2-page-scroll-config';
 import {PageScrollInstance, InterruptReporter} from './ng2-page-scroll-instance';
@@ -242,3 +242,13 @@ export class PageScrollService {
     }
 }
 
+/* singleton pattern taken from https://github.com/angular/angular/issues/13854 */
+export function NG2PAGESCROLL_SERVICE_PROVIDER_FACTORY(parentDispatcher: PageScrollService) {
+    return parentDispatcher || new PageScrollService();
+}
+
+export const NG2PAGESCROLL_SERVICE_PROVIDER = {
+    provide: PageScrollService,
+    deps: [[new Optional(), new SkipSelf(), PageScrollService]],
+    useFactory: NG2PAGESCROLL_SERVICE_PROVIDER_FACTORY
+};


### PR DESCRIPTION
The `forRoot` approach is flawed because in a scenario where the root module does not require the module but more than one lazily loaded module does, there is no way to only inject a singleton.

This pattern is taken from the Angular source code. Instead of doing

```
imports: [
  Ng2PageScrollModule.forRoot()
]
```

you can now just do
```
imports: [
  Ng2PageScrollModule
]
```